### PR TITLE
support Python 3

### DIFF
--- a/gvanim/__main__.py
+++ b/gvanim/__main__.py
@@ -18,7 +18,7 @@
 from argparse import ArgumentParser, FileType
 from sys import stdin
 
-import animation, render
+from . import animation, render
 
 def main():
 

--- a/gvanim/action.py
+++ b/gvanim/action.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License along with
 # "GraphvizAnim". If not, see <http://www.gnu.org/licenses/>.
 
-import animation
+from . import animation
 
 class NextStep( object ):
 	def __init__( self, clean = False ):

--- a/gvanim/action.py
+++ b/gvanim/action.py
@@ -15,12 +15,11 @@
 # You should have received a copy of the GNU General Public License along with
 # "GraphvizAnim". If not, see <http://www.gnu.org/licenses/>.
 
-from . import animation
-
 class NextStep( object ):
 	def __init__( self, clean = False ):
 		self.clean = clean
 	def __call__( self, steps ):
+		from . import animation
 		steps.append( animation.Step( None if self.clean else steps[ -1 ] ) )
 
 class AddNode( object ):

--- a/gvanim/animation.py
+++ b/gvanim/animation.py
@@ -18,7 +18,7 @@
 from email.utils import quote
 import shlex
 
-import action
+from . import action
 
 class ParseException( Exception ):
 	pass

--- a/gvanim/animation.py
+++ b/gvanim/animation.py
@@ -113,7 +113,7 @@ class Animation( object ):
 			except KeyError:
 				raise ParseException( 'unrecognized command: {}'.format( action ) )
 			except TypeError:
- 				raise ParseException( 'wrong number of parameters: {}'.format( line.strip() ) )
+				raise ParseException( 'wrong number of parameters: {}'.format( line.strip() ) )
 				return
 
 	def steps( self ):

--- a/gvanim/jupyter.py
+++ b/gvanim/jupyter.py
@@ -22,7 +22,7 @@ from shutil import rmtree
 from IPython.display import Image
 import ipywidgets as widgets
 
-from render import render
+from .render import render
 
 def interactive( animation, size = 320 ):
 	basedir = mkdtemp()

--- a/gvanim/render.py
+++ b/gvanim/render.py
@@ -22,7 +22,7 @@ def _render( params ):
 	path, fmt, size, graph = params
 	with open( path , 'w' ) as out:
 		pipe = Popen( [ 'dot',  '-Gsize=1,1!', '-Gdpi={}'.format( size ), '-T', fmt ], stdout = out, stdin = PIPE, stderr = None )
-		pipe.communicate( input = graph )
+		pipe.communicate( input = graph.encode() )
 	return path
 
 def render( graphs, basename, fmt = 'png', size = 320 ):


### PR DESCRIPTION
This patch contains multiple fixes to make this package work with Python 3:

* remove single space mixed with the tabs
* make relative imports work
* convert `str` input to `bytes`
* break circular imports by importing one direction in a local scope rather than module level

All changes should be backward compatible with Python 2